### PR TITLE
fix: link to next page

### DIFF
--- a/source/pages/Mapping_from_CPCDS_to_FHIR_Resources.md
+++ b/source/pages/Mapping_from_CPCDS_to_FHIR_Resources.md
@@ -4,8 +4,8 @@ layout: default
 active: Mapping from CPCDS to FHIR Resources
 ---
 
-[Previous Page](Common_Payer_Consumer_Data_Set_(CPCDS).html)
+[Previous Page](<Common_Payer_Consumer_Data_Set_(CPCDS).html>)
 
-Based on CPCDS, the mappings define the minimum mandatory elements, extensions and terminology requirements that must be present in the FHIR resource.  Additional business rules are specified.
+Based on CPCDS, the mappings define the minimum mandatory elements, extensions and terminology requirements that must be present in the FHIR resource. Additional business rules are specified.
 
-[Next Page](undefined)
+[Next Page](Data_Element_Index.html)


### PR DESCRIPTION
Hi all

The "Next Page" here -> https://build.fhir.org/ig/HL7/carin-bb/Mapping_from_CPCDS_to_FHIR_Resources.html is undefined, so I defined it to go to Data Element Index.

Thanks!
