### PR TITLE
FHIRPath fixes

### DIFF
--- a/fsh/EOBBaseProfile.fsh
+++ b/fsh/EOBBaseProfile.fsh
@@ -143,7 +143,7 @@ Expression: "(
 Severity: #error
 
 Invariant: EOB-pharm-careTeam-organization
-Description: "Pharmacy EOB:  Careteam roles refer to a practitioner"
+Description: "Pharmacy EOB:  Careteam roles refer to an organization"
 Expression: "( 
      careTeam.where(role.where(coding.where(code in ('performing')).exists()).exists()).exists() implies
      careTeam.where(role.where(coding.where(code in ('performing')).exists()).exists()).provider.all(resolve() is Organization)
@@ -167,5 +167,4 @@ Expression:
      careTeam.where(role.where(coding.where(code in ('site')).exists()).exists()).provider.all(resolve() is Organization)
     )"
 Severity: #error
-
 

--- a/fsh/EOBBaseProfile.fsh
+++ b/fsh/EOBBaseProfile.fsh
@@ -137,16 +137,16 @@ Severity: #error
 Invariant: EOB-pharm-careTeam-practitioner
 Description: "Pharmacy EOB:  Careteam roles refer to a practitioner"
 Expression: "( 
-     careTeam.where(role.where(coding.where(code in ( 'primary' or 'prescribing')).exists()).exists()).exists() implies
-     careTeam.where(role.where(coding.where(code in ( 'primary' or 'prescribing')).exists()).exists()).provider.all(resolve().is Practitioner)
+     careTeam.where(role.where(coding.where(code in ('primary' | 'prescribing')).exists()).exists()).exists() implies
+     careTeam.where(role.where(coding.where(code in ('primary' | 'prescribing')).exists()).exists()).provider.all(resolve() is Practitioner)
     )"
 Severity: #error
 
 Invariant: EOB-pharm-careTeam-organization
 Description: "Pharmacy EOB:  Careteam roles refer to a practitioner"
 Expression: "( 
-     careTeam.where(role.where(coding.where(code in ( 'performing')).exists()).exists()).exists() implies
-     careTeam.where(role.where(coding.where(code in ( 'performing')).exists()).exists()).provider.all(resolve().is Organization)
+     careTeam.where(role.where(coding.where(code in ('performing')).exists()).exists()).exists() implies
+     careTeam.where(role.where(coding.where(code in ('performing')).exists()).exists()).provider.all(resolve() is Organization)
     )"
 Severity: #error
 
@@ -154,8 +154,8 @@ Invariant: EOB-prof-careTeam-practitioner
 Description: "Professional EOB:  Careteam roles refer to a practitioner"
 Expression: 
    "( 
-     careTeam.where(role.where(coding.where(code in ('performing' or 'primary' or 'referring' or 'supervising')).exists()).exists()).exists() implies
-     careTeam.where(role.where(coding.where(code in ('performing' or 'primary' or 'referring' or 'supervising')).exists()).exists()).provider.all(resolve().is Practitioner)
+     careTeam.where(role.where(coding.where(code in ('performing' | 'primary' | 'referring' | 'supervising')).exists()).exists()).exists() implies
+     careTeam.where(role.where(coding.where(code in ('performing' | 'primary' | 'referring' | 'supervising')).exists()).exists()).provider.all(resolve() is Practitioner)
     )"
 Severity: #error
 
@@ -163,8 +163,8 @@ Invariant: EOB-prof-careTeam-organization
 Description: "Professional EOB:  Careteam roles refer to an organization"
 Expression: 
    "( 
-     careTeam.where(role.where(coding.where(code in ( 'site')).exists()).exists()).exists() implies
-     careTeam.where(role.where(coding.where(code in ( 'site')).exists()).exists()).provider.all(resolve().is Organization)
+     careTeam.where(role.where(coding.where(code in ('site')).exists()).exists()).exists() implies
+     careTeam.where(role.where(coding.where(code in ('site')).exists()).exists()).provider.all(resolve() is Organization)
     )"
 Severity: #error
 


### PR DESCRIPTION
Statements like `code in ( 'primary' or 'prescribing')` should be like `code in ( 'primary' | 'prescribing')` instead.
Also removed `.` from `resource(). is Practitioner`; is is being used as an operator here and not a function.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>